### PR TITLE
Make price calculations precise with Decimals instead of floats

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -142,38 +142,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.5.1"
+version = "1.6.0"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f33592ddf9655a4894aef22d134de7393e95fcbdc2d15c1ab65828eee5c66c70"},
-    {file = "mypy-1.5.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:258b22210a4a258ccd077426c7a181d789d1121aca6db73a83f79372f5569ae0"},
-    {file = "mypy-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9ec1f695f0c25986e6f7f8778e5ce61659063268836a38c951200c57479cc12"},
-    {file = "mypy-1.5.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:abed92d9c8f08643c7d831300b739562b0a6c9fcb028d211134fc9ab20ccad5d"},
-    {file = "mypy-1.5.1-cp310-cp310-win_amd64.whl", hash = "sha256:a156e6390944c265eb56afa67c74c0636f10283429171018446b732f1a05af25"},
-    {file = "mypy-1.5.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6ac9c21bfe7bc9f7f1b6fae441746e6a106e48fc9de530dea29e8cd37a2c0cc4"},
-    {file = "mypy-1.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:51cb1323064b1099e177098cb939eab2da42fea5d818d40113957ec954fc85f4"},
-    {file = "mypy-1.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:596fae69f2bfcb7305808c75c00f81fe2829b6236eadda536f00610ac5ec2243"},
-    {file = "mypy-1.5.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:32cb59609b0534f0bd67faebb6e022fe534bdb0e2ecab4290d683d248be1b275"},
-    {file = "mypy-1.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:159aa9acb16086b79bbb0016145034a1a05360626046a929f84579ce1666b315"},
-    {file = "mypy-1.5.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:f6b0e77db9ff4fda74de7df13f30016a0a663928d669c9f2c057048ba44f09bb"},
-    {file = "mypy-1.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26f71b535dfc158a71264e6dc805a9f8d2e60b67215ca0bfa26e2e1aa4d4d373"},
-    {file = "mypy-1.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fc3a600f749b1008cc75e02b6fb3d4db8dbcca2d733030fe7a3b3502902f161"},
-    {file = "mypy-1.5.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:26fb32e4d4afa205b24bf645eddfbb36a1e17e995c5c99d6d00edb24b693406a"},
-    {file = "mypy-1.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:82cb6193de9bbb3844bab4c7cf80e6227d5225cc7625b068a06d005d861ad5f1"},
-    {file = "mypy-1.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4a465ea2ca12804d5b34bb056be3a29dc47aea5973b892d0417c6a10a40b2d65"},
-    {file = "mypy-1.5.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9fece120dbb041771a63eb95e4896791386fe287fefb2837258925b8326d6160"},
-    {file = "mypy-1.5.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d28ddc3e3dfeab553e743e532fb95b4e6afad51d4706dd22f28e1e5e664828d2"},
-    {file = "mypy-1.5.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:57b10c56016adce71fba6bc6e9fd45d8083f74361f629390c556738565af8eeb"},
-    {file = "mypy-1.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:ff0cedc84184115202475bbb46dd99f8dcb87fe24d5d0ddfc0fe6b8575c88d2f"},
-    {file = "mypy-1.5.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8f772942d372c8cbac575be99f9cc9d9fb3bd95c8bc2de6c01411e2c84ebca8a"},
-    {file = "mypy-1.5.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5d627124700b92b6bbaa99f27cbe615c8ea7b3402960f6372ea7d65faf376c14"},
-    {file = "mypy-1.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:361da43c4f5a96173220eb53340ace68cda81845cd88218f8862dfb0adc8cddb"},
-    {file = "mypy-1.5.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:330857f9507c24de5c5724235e66858f8364a0693894342485e543f5b07c8693"},
-    {file = "mypy-1.5.1-cp39-cp39-win_amd64.whl", hash = "sha256:c543214ffdd422623e9fedd0869166c2f16affe4ba37463975043ef7d2ea8770"},
-    {file = "mypy-1.5.1-py3-none-any.whl", hash = "sha256:f757063a83970d67c444f6e01d9550a7402322af3557ce7630d3c957386fa8f5"},
-    {file = "mypy-1.5.1.tar.gz", hash = "sha256:b031b9601f1060bf1281feab89697324726ba0c0bae9d7cd7ab4b690940f0b92"},
+    {file = "mypy-1.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:091f53ff88cb093dcc33c29eee522c087a438df65eb92acd371161c1f4380ff0"},
+    {file = "mypy-1.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eb7ff4007865833c470a601498ba30462b7374342580e2346bf7884557e40531"},
+    {file = "mypy-1.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49499cf1e464f533fc45be54d20a6351a312f96ae7892d8e9f1708140e27ce41"},
+    {file = "mypy-1.6.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4c192445899c69f07874dabda7e931b0cc811ea055bf82c1ababf358b9b2a72c"},
+    {file = "mypy-1.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:3df87094028e52766b0a59a3e46481bb98b27986ed6ded6a6cc35ecc75bb9182"},
+    {file = "mypy-1.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c8835a07b8442da900db47ccfda76c92c69c3a575872a5b764332c4bacb5a0a"},
+    {file = "mypy-1.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:24f3de8b9e7021cd794ad9dfbf2e9fe3f069ff5e28cb57af6f873ffec1cb0425"},
+    {file = "mypy-1.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:856bad61ebc7d21dbc019b719e98303dc6256cec6dcc9ebb0b214b81d6901bd8"},
+    {file = "mypy-1.6.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:89513ddfda06b5c8ebd64f026d20a61ef264e89125dc82633f3c34eeb50e7d60"},
+    {file = "mypy-1.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:9f8464ed410ada641c29f5de3e6716cbdd4f460b31cf755b2af52f2d5ea79ead"},
+    {file = "mypy-1.6.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:971104bcb180e4fed0d7bd85504c9036346ab44b7416c75dd93b5c8c6bb7e28f"},
+    {file = "mypy-1.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab98b8f6fdf669711f3abe83a745f67f50e3cbaea3998b90e8608d2b459fd566"},
+    {file = "mypy-1.6.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a69db3018b87b3e6e9dd28970f983ea6c933800c9edf8c503c3135b3274d5ad"},
+    {file = "mypy-1.6.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:dccd850a2e3863891871c9e16c54c742dba5470f5120ffed8152956e9e0a5e13"},
+    {file = "mypy-1.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:f8598307150b5722854f035d2e70a1ad9cc3c72d392c34fffd8c66d888c90f17"},
+    {file = "mypy-1.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fea451a3125bf0bfe716e5d7ad4b92033c471e4b5b3e154c67525539d14dc15a"},
+    {file = "mypy-1.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e28d7b221898c401494f3b77db3bac78a03ad0a0fff29a950317d87885c655d2"},
+    {file = "mypy-1.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4b7a99275a61aa22256bab5839c35fe8a6887781862471df82afb4b445daae6"},
+    {file = "mypy-1.6.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7469545380dddce5719e3656b80bdfbb217cfe8dbb1438532d6abc754b828fed"},
+    {file = "mypy-1.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:7807a2a61e636af9ca247ba8494031fb060a0a744b9fee7de3a54bed8a753323"},
+    {file = "mypy-1.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d2dad072e01764823d4b2f06bc7365bb1d4b6c2f38c4d42fade3c8d45b0b4b67"},
+    {file = "mypy-1.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b19006055dde8a5425baa5f3b57a19fa79df621606540493e5e893500148c72f"},
+    {file = "mypy-1.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31eba8a7a71f0071f55227a8057468b8d2eb5bf578c8502c7f01abaec8141b2f"},
+    {file = "mypy-1.6.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8e0db37ac4ebb2fee7702767dfc1b773c7365731c22787cb99f507285014fcaf"},
+    {file = "mypy-1.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:c69051274762cccd13498b568ed2430f8d22baa4b179911ad0c1577d336ed849"},
+    {file = "mypy-1.6.0-py3-none-any.whl", hash = "sha256:9e1589ca150a51d9d00bb839bfeca2f7a04f32cd62fad87a847bc0818e15d7dc"},
+    {file = "mypy-1.6.0.tar.gz", hash = "sha256:4f3d27537abde1be6d5f2c96c29a454da333a2a271ae7d5bc7110e6d4b7beb3f"},
 ]
 
 [package.dependencies]
@@ -318,4 +318,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.10.13"
-content-hash = "d6779c6faf3b7f932ed8a29a646aff4f4b2e31a472b0914f699f81fb8a177038"
+content-hash = "d5fd7d60d37f607a6f2c9b7e72965cd95ae073d63f83ba98569d8ed5ff1761a7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ python = "~3.10.13"
 
 [tool.poetry.group.dev.dependencies]
 flake8 = "^6.0.0"
-mypy = "^1.4.1"
+mypy = "^1.6.0"
 isort = "^5.12.0"
 pytest = "^7.4.0"
 black = "^23.7.0"

--- a/supermarket_pricing/catalogue.py
+++ b/supermarket_pricing/catalogue.py
@@ -6,23 +6,25 @@ from supermarket_pricing.offers import (
     ThreeFromSetForPrice,
     TwoForPrice,
 )
-from supermarket_pricing.product import Product, ProductByKg
+from supermarket_pricing.product import Price, Product, ProductByKg
 
 PRODUCT_CATALOGUE: Dict[str, Product] = {
-    "beans": Product("beans", 0.5),
-    "coke": Product("coke", 0.7),
-    "onions": ProductByKg("onions", 0.29),
-    "oranges": ProductByKg("oranges", 1.99),
-    "arbor ale": Product("arbor ale", 2.2),
-    "kaleidoscope": Product("kaleidoscope", 2.5),
-    "butcombe": Product("butcombe", 2.1),
+    "beans": Product("beans", Price("0.5")),
+    "coke": Product("coke", Price("0.7")),
+    "onions": ProductByKg("onions", Price("0.29")),
+    "oranges": ProductByKg("oranges", Price("1.99")),
+    "arbor ale": Product("arbor ale", Price("2.2")),
+    "kaleidoscope": Product("kaleidoscope", Price("2.5")),
+    "butcombe": Product("butcombe", Price("2.1")),
 }
 
 
 OFFERS: List[Offer] = [
     ThreeForTwo(PRODUCT_CATALOGUE["beans"]),
-    TwoForPrice(PRODUCT_CATALOGUE["coke"], 1.0),
+    TwoForPrice(PRODUCT_CATALOGUE["coke"], Price("1")),
     ThreeFromSetForPrice(
-        [PRODUCT_CATALOGUE["arbor ale"], PRODUCT_CATALOGUE["kaleidoscope"], PRODUCT_CATALOGUE["butcombe"]], 6.0, "ales"
+        [PRODUCT_CATALOGUE["arbor ale"], PRODUCT_CATALOGUE["kaleidoscope"], PRODUCT_CATALOGUE["butcombe"]],
+        Price("6"),
+        "ales",
     ),
 ]

--- a/supermarket_pricing/exceptions.py
+++ b/supermarket_pricing/exceptions.py
@@ -8,3 +8,7 @@ class ProductQuantityException(ShoppingCartException):
 
 class InvalidProductException(ShoppingCartException):
     pass
+
+
+class ProductException(Exception):
+    pass

--- a/supermarket_pricing/offers.py
+++ b/supermarket_pricing/offers.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from decimal import Decimal
 from typing import Dict, List, Type
 
-from supermarket_pricing.product import Product
+from supermarket_pricing.product import Price, Product
 
 
 class Offer(ABC):
@@ -9,17 +10,17 @@ class Offer(ABC):
         self.short_description = ""
 
     @abstractmethod
-    def is_eligible(self, product_quantities: Dict[str, float]) -> bool:
+    def is_eligible(self, product_quantities: Dict[str, Decimal]) -> bool:
         raise NotImplementedError
 
     @abstractmethod
-    def offer_amount(self, product_quantities: Dict[str, float]) -> float:
+    def offer_amount(self, product_quantities: Dict[str, Decimal]) -> Price:
         raise NotImplementedError
 
-    def check_and_apply(self, product_quantities: Dict[str, float]) -> float:
+    def check_and_apply(self, product_quantities: Dict[str, Decimal]) -> Price:
         if self.is_eligible(product_quantities):
-            return round(self.offer_amount(product_quantities), 2)
-        return 0
+            return self.offer_amount(product_quantities)
+        return Price(0)
 
 
 class ThreeForTwo(Offer):
@@ -27,40 +28,41 @@ class ThreeForTwo(Offer):
         self.eligible_product = eligible_product
         self.short_description = f"{eligible_product.name} 3 for 2"
 
-    def is_eligible(self, product_quantities: Dict[str, float]) -> bool:
+    def is_eligible(self, product_quantities: Dict[str, Decimal]) -> bool:
         return product_quantities.get(self.eligible_product.name, 0) >= 3
 
-    def offer_amount(self, product_quantities: Dict[str, float]) -> float:
+    def offer_amount(self, product_quantities: Dict[str, Decimal]) -> Price:
         number_of_offers = product_quantities[self.eligible_product.name] // 3
-        return number_of_offers * self.eligible_product.price
+        product_price: Price = self.eligible_product.price
+        return Price(number_of_offers * product_price)
 
 
 class TwoForPrice(Offer):
-    def __init__(self, eligible_product: Product | type[Product], offer_price: float) -> None:
+    def __init__(self, eligible_product: Product | type[Product], offer_price: Price) -> None:
         self.eligible_product = eligible_product
         self.offer_price = offer_price
-        self.short_description = f"{eligible_product.name} 2 for £{offer_price:.2f}"
+        self.short_description = f"{eligible_product.name} 2 for {str(offer_price)}"
 
-    def is_eligible(self, product_quantities: Dict[str, float]) -> bool:
+    def is_eligible(self, product_quantities: Dict[str, Decimal]) -> bool:
         return product_quantities.get(self.eligible_product.name, 0) >= 2
 
-    def offer_amount(self, product_quantities: Dict[str, float]) -> float:
+    def offer_amount(self, product_quantities: Dict[str, Decimal]) -> Price:
         number_of_offers = product_quantities[self.eligible_product.name] // 2
         saving_per_offer = (self.eligible_product.price * 2) - self.offer_price
-        return number_of_offers * saving_per_offer
+        return Price(number_of_offers * saving_per_offer)
 
 
 class ThreeFromSetForPrice(Offer):
     def __init__(
-        self, eligible_products: List[Product | type[Product]], offer_price: float, offer_category: str
+        self, eligible_products: List[Product | type[Product]], offer_price: Decimal, offer_category: str
     ) -> None:
         self.eligible_products = eligible_products
         self.offer_price = offer_price
-        self.short_description = f"{offer_category} 3 for £{offer_price:.2f}"
+        self.short_description = f"{offer_category} 3 for {str(offer_price)}"
         self.product_list: List[Product | Type[Product]] = []
         self.eligible_product_count = 0
 
-    def is_eligible(self, product_quantities: Dict[str, float]) -> bool:
+    def is_eligible(self, product_quantities: Dict[str, Decimal]) -> bool:
         eligible_product_names = [product.name for product in self.eligible_products]
         found_products = {key: value for key, value in product_quantities.items() if key in eligible_product_names}
         products_sorted_by_price = sorted(self.eligible_products, key=lambda product: product.price)
@@ -70,9 +72,9 @@ class ThreeFromSetForPrice(Offer):
         self.eligible_product_count = len(self.product_list)
         return self.eligible_product_count >= 3
 
-    def offer_amount(self, _product_quantities: Dict[str, float]) -> float:
+    def offer_amount(self, _product_quantities: Dict[str, Decimal]) -> Price:
         number_of_offers = self.eligible_product_count // 3
         # Discount the cheapest products in the deal
         discounted_products = self.product_list[: number_of_offers * 3]
         pre_discounted_price = sum(product.price for product in discounted_products)
-        return pre_discounted_price - (number_of_offers * self.offer_price)
+        return Price(pre_discounted_price - (number_of_offers * self.offer_price))

--- a/supermarket_pricing/product.py
+++ b/supermarket_pricing/product.py
@@ -1,5 +1,34 @@
 from dataclasses import dataclass
+from decimal import Decimal, getcontext
 from enum import Enum
+
+from supermarket_pricing.exceptions import InvalidProductException
+
+
+class Price(Decimal):
+    def __str__(self):
+        getcontext().rounding = "ROUND_DOWN"
+        return f"£{self.quantize(Decimal('00.00')):.2f}"
+
+    def __add__(self, other):
+        result = super().__add__(other)
+        if isinstance(other, Price):
+            return Price(result)
+        return Price(super(Price, result))
+
+    def __sub__(self, other):
+        result = super().__sub__(other)
+        return Price(result)
+
+    def __mul__(self, other):
+        result = super().__mul__(other)
+        return Price(result)
+
+
+class Weight(Decimal):
+    def __str__(self):
+        getcontext().rounding = "ROUND_DOWN"
+        return f"{self.quantize(Decimal('0.000')):.3f}"
 
 
 class PricingUnits(str, Enum):
@@ -10,8 +39,16 @@ class PricingUnits(str, Enum):
 @dataclass
 class Product:
     name: str
-    price: float
+    price: Price
     pricing_unit = PricingUnits.UNIT
+
+    def __post_init__(self):
+        if (
+            self.price.as_tuple().exponent < -2
+        ):  # Eventhough this can be rounded down, it's likely a mistake if more than 2 decimal places are specified
+            raise InvalidProductException(
+                f"Invalid product price {self.price}: must not have more than 2 decimal places"
+            )
 
 
 @dataclass

--- a/supermarket_pricing/receipt_printer.py
+++ b/supermarket_pricing/receipt_printer.py
@@ -1,11 +1,11 @@
 from typing import Union
 
+from supermarket_pricing.product import Price
 from supermarket_pricing.shopping_cart import ShoppingCart
 
 
-def print_receipt_row(description: str, price: Union[str, float] = "") -> None:
-    formatted_price = f"£{price:.2f}" if isinstance(price, float) else price
-    print("|", description.ljust(20), "|", formatted_price.rjust(6), "|")
+def print_receipt_row(description: str, price: Union[str, Price] = "") -> None:
+    print("|", description.ljust(20), "|", str(price).rjust(6), "|")
 
 
 def print_receipt(cart: ShoppingCart) -> None:
@@ -13,7 +13,7 @@ def print_receipt(cart: ShoppingCart) -> None:
         product_name = product.name.capitalize()
         if product.price_per_kg:
             print_receipt_row(product_name)
-            print_receipt_row(f"{product.quantity:.3f} kg @ £{product.price_per_kg:.2f}/kg", product.price)
+            print_receipt_row(f"{str(product.quantity)} kg @ {str(product.price_per_kg)}/kg", product.price)
         else:
             quantity = f" x {product.quantity}" if product.quantity != 1 else ""
             print_receipt_row(f"{product_name}{quantity}", product.price)
@@ -21,6 +21,6 @@ def print_receipt(cart: ShoppingCart) -> None:
         print_receipt_row("**Sub-total**", cart.sub_total)
         print_receipt_row("**Savings**")
         for offer in cart.applied_offers:
-            print_receipt_row(offer.description.capitalize(), f"-£{offer.offer_amount:.2f}")
+            print_receipt_row(offer.description.capitalize(), f"-{str(offer.offer_amount)}")
         print_receipt_row("**Total savings**", cart.savings)
     print_receipt_row("**Total to Pay**", cart.total)

--- a/supermarket_pricing/shopping_cart.py
+++ b/supermarket_pricing/shopping_cart.py
@@ -1,5 +1,5 @@
-import math
 from collections import namedtuple
+from decimal import ROUND_DOWN, Decimal
 from typing import Dict, List
 
 from supermarket_pricing.catalogue import OFFERS, PRODUCT_CATALOGUE
@@ -8,7 +8,7 @@ from supermarket_pricing.exceptions import (
     ProductQuantityException,
 )
 from supermarket_pricing.offers import Offer
-from supermarket_pricing.product import PricingUnits, Product
+from supermarket_pricing.product import Price, PricingUnits, Product, Weight
 
 AddedProduct = namedtuple("AddedProduct", "name quantity price price_per_kg")
 AppliedOffer = namedtuple("AppliedOffer", "description offer_amount")
@@ -22,35 +22,34 @@ class ShoppingCart:
     ) -> None:
         self.product_catalogue = product_catalogue
         self.offers_catalogue = offers_catalogue
-        self.product_quantities: Dict[str, float] = {}
+        self.product_quantities: Dict[str, Decimal] = {}
         self.products_in_cart: List[AddedProduct] = []
         self.applied_offers: List[AppliedOffer] = []
 
-    def add_product(self, product_name: str, quantity: float = 1.0) -> None:
+    def add_product(self, product_name: str, input_quantity: str = "1") -> None:
         if product := self.product_catalogue.get(product_name):
-            if product.pricing_unit == PricingUnits.UNIT and not float(quantity).is_integer():
+            quantity = Weight(input_quantity) if product.pricing_unit == PricingUnits.KG else Decimal(input_quantity)
+            if quantity <= 0:
+                raise ProductQuantityException(f"Product quantity for {product_name} must be a positive value")
+            if product.pricing_unit == PricingUnits.UNIT and not self.__decimal_is_int(quantity):
                 raise ProductQuantityException(f"Product quantity for {product_name} must be specified in integers")
             self.product_quantities[product_name] = self.product_quantities.get(product_name, 0) + quantity
             price_per_kg = product.price if product.pricing_unit == PricingUnits.KG else 0
             self.products_in_cart.append(
-                AddedProduct(product_name, quantity, self.__get_product_quantity_price(product, quantity), price_per_kg)
+                AddedProduct(
+                    product_name, quantity, self.__round_down_price(Price(product.price * quantity)), price_per_kg
+                )
             )
         else:
             raise InvalidProductException("Unexpected Item in Bagging Area")
 
-    def __get_product_quantity_price(self, product: Product, quantity: float) -> float:
-        if product.pricing_unit == PricingUnits.UNIT:
-            return product.price * quantity
-        elif product.pricing_unit == PricingUnits.KG:
-            return self.__round_down_price(product.price * quantity)
+    @property
+    def sub_total(self) -> Price:
+        return sum((product.price for product in self.products_in_cart), Price(0))
 
     @property
-    def sub_total(self) -> float:
-        return sum(product.price for product in self.products_in_cart)
-
-    @property
-    def savings(self) -> float:
-        savings = 0.0
+    def savings(self) -> Price:
+        savings: Price = Price(0.0)
         applied_offers: List[AppliedOffer] = []
         for offer in self.offers_catalogue:
             if (offer_amount := offer.check_and_apply(self.product_quantities)) > 0:
@@ -60,10 +59,14 @@ class ShoppingCart:
         return savings
 
     @property
-    def total(self) -> float:
+    def total(self) -> Price:
         return self.sub_total - self.savings
 
     @staticmethod
-    def __round_down_price(price: float) -> float:
-        minimum_price = 0.01
-        return max(minimum_price, math.floor((price) * 100) / 100)
+    def __decimal_is_int(number: Decimal):
+        return number.as_integer_ratio()[1] == 1
+
+    @staticmethod
+    def __round_down_price(price: Price) -> Price:
+        minimum_price = Price("0.01")
+        return Price(max(minimum_price, price.quantize(Price("0.00"), rounding=ROUND_DOWN)))

--- a/tests/end_to_end/test_end_to_end.py
+++ b/tests/end_to_end/test_end_to_end.py
@@ -7,7 +7,7 @@ def test_supermarket_receipt_without_offers(capsys):
     cart.add_product("beans")
     cart.add_product("butcombe")
     cart.add_product("coke")
-    cart.add_product("onions", 1.2777)
+    cart.add_product("onions", "1.2777")
     cart.add_product("beans")
     print_receipt(cart)
     captured = capsys.readouterr()
@@ -15,7 +15,7 @@ def test_supermarket_receipt_without_offers(capsys):
 | Butcombe             |  £2.10 |
 | Coke                 |  £0.70 |
 | Onions               |        |
-| 1.278 kg @ £0.29/kg  |  £0.37 |
+| 1.277 kg @ £0.29/kg  |  £0.37 |
 | Beans                |  £0.50 |
 | **Total to Pay**     |  £4.17 |
 """
@@ -29,7 +29,7 @@ def test_supermarket_receipt_with_offers(capsys):
     cart.add_product("beans")
     cart.add_product("coke")
     cart.add_product("coke")
-    cart.add_product("oranges", 0.2)
+    cart.add_product("oranges", "0.2")
     cart.add_product("arbor ale")
     cart.add_product("kaleidoscope")
     cart.add_product("kaleidoscope")

--- a/tests/unit/test_offers.py
+++ b/tests/unit/test_offers.py
@@ -2,16 +2,16 @@ from typing import Dict, Type, Union
 
 import pytest
 from supermarket_pricing.offers import ThreeForTwo, ThreeFromSetForPrice, TwoForPrice
-from supermarket_pricing.product import Product
+from supermarket_pricing.product import Price, Product
 
 
 @pytest.fixture
 def test_product_catalogue() -> Dict[str, Union[Product, Type[Product]]]:
     return {
-        "a": Product("a", 1.0),
-        "b": Product("b", 1.0),
-        "c": Product("c", 1.1),
-        "d": Product("d", 1.2),
+        "a": Product("a", Price("1")),
+        "b": Product("b", Price("1")),
+        "c": Product("c", Price("1.1")),
+        "d": Product("d", Price("1.2")),
     }
 
 
@@ -21,7 +21,7 @@ def test_singular_three_for_two_offer(test_product_catalogue):
     discount_amount = offer.check_and_apply(cart_count)
     # Before Discount = 3 * 1.0= 3.0
     # After Discount = 3.0 - 1.0 = 2.0
-    assert discount_amount == 1.0
+    assert discount_amount == Price("1")
 
 
 def test_multiple_three_for_two_offer(test_product_catalogue):
@@ -30,30 +30,30 @@ def test_multiple_three_for_two_offer(test_product_catalogue):
     discount_amount = offer.check_and_apply(cart_count)
     # Before Discount = 7 * 1.0= 7.0
     # After Discount = 7.0 - 2.0 = 5.0
-    assert discount_amount == 2.0
+    assert discount_amount == Price("2")
 
 
 def test_singular_two_for_price_offer(test_product_catalogue):
-    offer = TwoForPrice(test_product_catalogue["b"], 1.5)
+    offer = TwoForPrice(test_product_catalogue["b"], Price("1.5"))
     cart_count = {"b": 2}  # Price 1.0
     discount_amount = offer.check_and_apply(cart_count)
     # Before Discount = 2 * 1.0 = 2.0
     # After Discount = 2.0 - 1.5 - 0.5
-    assert discount_amount == 0.5
+    assert discount_amount == Price("0.5")
 
 
 def test_multiple_two_for_price_offer(test_product_catalogue):
-    offer = TwoForPrice(test_product_catalogue["b"], 1.5)
+    offer = TwoForPrice(test_product_catalogue["b"], Price("1.5"))
     cart_count = {"b": 5}  # Price 1.0
     discount_amount = offer.check_and_apply(cart_count)
     # Before Discount = 5 * 1.0 = 5.0
     # After Discount = 1.5 + 1.5 + 1.0 = 4.0
-    assert discount_amount == 1.0
+    assert discount_amount == Price("1")
 
 
 def test_singular_three_from_set_offer(test_product_catalogue):
     offer = ThreeFromSetForPrice(
-        [test_product_catalogue["b"], test_product_catalogue["c"], test_product_catalogue["d"]], 3.0, "letters"
+        [test_product_catalogue["b"], test_product_catalogue["c"], test_product_catalogue["d"]], Price("3.0"), "letters"
     )
     cart_count = {
         "b": 1,  # Price 1.0
@@ -63,12 +63,12 @@ def test_singular_three_from_set_offer(test_product_catalogue):
     discount_amount = offer.check_and_apply(cart_count)
     # Before Discount = 3.3
     # After Discount = 3.3 + 3.0 = 0.3
-    assert discount_amount == 0.3
+    assert discount_amount == Price("0.3")
 
 
 def test_multiple_three_from_set_offer(test_product_catalogue):
     offer = ThreeFromSetForPrice(
-        [test_product_catalogue["b"], test_product_catalogue["c"], test_product_catalogue["d"]], 3.0, "letters"
+        [test_product_catalogue["b"], test_product_catalogue["c"], test_product_catalogue["d"]], Price("3.0"), "letters"
     )
     cart_count = {
         "b": 1,  # Price 1.0
@@ -78,4 +78,4 @@ def test_multiple_three_from_set_offer(test_product_catalogue):
     discount_amount = offer.check_and_apply(cart_count)
     # Before Discount = 3.6 + 3.3 + 1.0 = 7.9
     # After Discount = 6.0 + 1.2 = 7.2
-    assert discount_amount == 0.7  # Only discounts 6 cheapest out of the 7
+    assert discount_amount == Price("0.7")  # Only discounts 6 cheapest out of the 7

--- a/tests/unit/test_product.py
+++ b/tests/unit/test_product.py
@@ -1,0 +1,41 @@
+import pytest
+from supermarket_pricing.exceptions import InvalidProductException
+from supermarket_pricing.product import Price, Product, Weight
+
+
+@pytest.mark.parametrize(
+    "price, price_string",
+    [
+        (Price("5.235"), "£5.23"),
+        (Price("0.999"), "£0.99"),
+        (Price("1.12214930"), "£1.12"),
+        (Price("1.1"), "£1.10"),
+        (Price("111.001"), "£111.00"),
+    ],
+)
+def test_price_class_prints_to_two_decimal_places(capsys, price, price_string):
+    print(price)
+    captured = capsys.readouterr()
+    assert captured.out == price_string + "\n"
+
+
+@pytest.mark.parametrize(
+    "price, price_string",
+    [
+        (Weight("5.235"), "5.235"),
+        (Weight("0.9999"), "0.999"),
+        (Weight("1.12214930"), "1.122"),
+        (Weight("1.1"), "1.100"),
+        (Weight("111.0001"), "111.000"),
+    ],
+)
+def test_weight_class_prints_to_three_decimal_places(capsys, price, price_string):
+    print(price)
+    captured = capsys.readouterr()
+    assert captured.out == price_string + "\n"
+
+
+def test_raises_product_with_invalid_price():
+    with pytest.raises(InvalidProductException) as e:
+        Product("foo", Price("0.333"))
+    assert "Invalid product price 0.333: must not have more than 2 decimal places" in e.value.args[0]

--- a/tests/unit/test_shopping_cart.py
+++ b/tests/unit/test_shopping_cart.py
@@ -66,25 +66,20 @@ def test_raises_for_invalid_item():
     assert "Unexpected Item in Bagging Area" in e.value.args[0]
 
 
-def test_raises_for_invalid_item_quantity():
+@pytest.mark.parametrize(
+    "input_value, error",
+    [
+        ("1.5", "specified in integers"),
+        ("0", "a positive value"),
+        ("-8", "a positive value"),
+        ("a million", "a valid number"),
+    ],
+)
+def test_raises_for_invalid_item_quantity(input_value, error):
     cart = ShoppingCart()
     with pytest.raises(ProductQuantityException) as e:
-        cart.add_product("coke", "1.5")
-    assert "Product quantity for coke must be specified in integers" in e.value.args[0]
-
-
-def test_raises_for_zero_item_quantity():
-    cart = ShoppingCart()
-    with pytest.raises(ProductQuantityException) as e:
-        cart.add_product("coke", "0")
-    assert "Product quantity for coke must be a positive value" in e.value.args[0]
-
-
-def test_raises_for_negative_item_quantity():
-    cart = ShoppingCart()
-    with pytest.raises(ProductQuantityException) as e:
-        cart.add_product("coke", "-8")
-    assert "Product quantity for coke must be a positive value" in e.value.args[0]
+        cart.add_product("coke", input_value)
+    assert f"Product quantity for coke must be {error}" in e.value.args[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_shopping_cart.py
+++ b/tests/unit/test_shopping_cart.py
@@ -1,34 +1,37 @@
+from decimal import Decimal
+
 import pytest
 from supermarket_pricing.exceptions import (
     InvalidProductException,
     ProductQuantityException,
 )
+from supermarket_pricing.product import Price
 from supermarket_pricing.shopping_cart import ShoppingCart
 
 
 def test_get_total_for_one_item():
     cart = ShoppingCart()
     cart.add_product("beans")
-    assert cart.sub_total == 0.5
-    assert cart.savings == 0
-    assert cart.total == 0.5
+    assert cart.sub_total == Price("0.5")
+    assert cart.savings == Price("0")
+    assert cart.total == Price("0.5")
 
 
 def test_get_total_for_multiple_of_same_item():
     cart = ShoppingCart()
     cart.add_product("beans")
-    cart.add_product("beans", 2)
-    assert cart.sub_total == 1.5
-    assert cart.savings == 0.5
-    assert cart.total == 1.0
+    cart.add_product("beans", "2")
+    assert cart.sub_total == Price("1.5")
+    assert cart.savings == Price("0.5")
+    assert cart.total == Price("1")
 
 
 def test_get_total_for_item_by_kg():
     cart = ShoppingCart()
-    cart.add_product("onions", 0.55)
-    assert cart.sub_total == 0.15
-    assert cart.savings == 0
-    assert cart.total == 0.15
+    cart.add_product("onions", "0.55")
+    assert cart.sub_total == Price("0.15")
+    assert cart.savings == Price("0")
+    assert cart.total == Price("0.15")
 
 
 def test_get_total_for_multiple_items_without_offers():
@@ -36,11 +39,11 @@ def test_get_total_for_multiple_items_without_offers():
     cart.add_product("beans")
     cart.add_product("butcombe")
     cart.add_product("coke")
-    cart.add_product("onions", 1.2777)
+    cart.add_product("onions", "1.2777")
     cart.add_product("beans")
-    assert cart.sub_total == 4.17
-    assert cart.savings == 0
-    assert cart.total == 4.17
+    assert cart.sub_total == Price("4.17")
+    assert cart.savings == Price("0")
+    assert cart.total == Price("4.17")
 
 
 def test_get_total_for_with_offers():
@@ -51,9 +54,9 @@ def test_get_total_for_with_offers():
     cart.add_product("coke")  # 0.7
     cart.add_product("beans")  # 0.5
     cart.add_product("beans")  # 0.5
-    assert cart.sub_total == 4.8
-    assert cart.savings == 0.5  # 3 for 2 beans
-    assert cart.total == 4.3
+    assert cart.sub_total == Price("4.8")
+    assert cart.savings == Price("0.5")  # 3 for 2 beans
+    assert cart.total == Price("4.3")
 
 
 def test_raises_for_invalid_item():
@@ -66,12 +69,48 @@ def test_raises_for_invalid_item():
 def test_raises_for_invalid_item_quantity():
     cart = ShoppingCart()
     with pytest.raises(ProductQuantityException) as e:
-        cart.add_product("coke", 1.5)
+        cart.add_product("coke", "1.5")
     assert "Product quantity for coke must be specified in integers" in e.value.args[0]
 
 
-def test_product_price_rounded_down_to_2_decimal_places():
-    input_prices = [5.235, 0.999, 1.12214930, 1.1, 0.001]
-    rounded_prices = [ShoppingCart._ShoppingCart__round_down_price(price) for price in input_prices]
-    expected_prices = [5.23, 0.99, 1.12, 1.1, 0.01]
-    assert rounded_prices == expected_prices
+def test_raises_for_zero_item_quantity():
+    cart = ShoppingCart()
+    with pytest.raises(ProductQuantityException) as e:
+        cart.add_product("coke", "0")
+    assert "Product quantity for coke must be a positive value" in e.value.args[0]
+
+
+def test_raises_for_negative_item_quantity():
+    cart = ShoppingCart()
+    with pytest.raises(ProductQuantityException) as e:
+        cart.add_product("coke", "-8")
+    assert "Product quantity for coke must be a positive value" in e.value.args[0]
+
+
+@pytest.mark.parametrize(
+    "input_price, expected_price",
+    [
+        (Price("5.235"), Price("5.23")),
+        (Price("0.999"), Price("0.99")),
+        (Price("1.12214930"), Price("1.12")),
+        (Price("1.1"), Price("1.10")),
+        (Price("0.001"), Price("0.01")),
+    ],
+)
+def test_product_price_rounded_down_to_2_decimal_places(input_price, expected_price):
+    rounded_price = ShoppingCart._ShoppingCart__round_down_price(input_price)
+    assert rounded_price == expected_price
+
+
+@pytest.mark.parametrize(
+    "input, expected",
+    [
+        (Decimal("5.235"), False),
+        (Decimal("5.000000000001"), False),
+        (Decimal("2.00000000"), True),
+        (Decimal("3"), True),
+    ],
+)
+def test_decimal_is_int(input, expected):
+    is_int = ShoppingCart._ShoppingCart__decimal_is_int(input)
+    assert is_int == expected


### PR DESCRIPTION
* Change price and quantities to be handled with Decimals instead of floats, as floats are prone to precision errors ef:
```
 >>> float(10.0-9.2)
0.8000000000000007
```

* Create custom classes of Decimal to enforce particular rounding behaviours and to make rounding and string formatting consistent, previously this was done in multiple places which is error prone
* Make everything round down to be nice to the customers :) 
* Add error handing for adding 0 or less items to the cart
* Add error handing for adding non-number quantities of items to the cart